### PR TITLE
Use Serial for Disk Entity Names

### DIFF
--- a/custom_components/truenas/sensor.py
+++ b/custom_components/truenas/sensor.py
@@ -56,7 +56,7 @@ class DiskTemperatureSensor(TrueNASDiskEntity, TrueNASSensor, Entity):
     def name(self) -> str:
         """Return the name of the disk."""
         assert self._disk is not None
-        return f"{self._disk.name} Disk Temperature"
+        return f"Disk {self._disk.serial} Temperature"
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
`[a]da[0-9]` can change for a given disk for a variety of reasons, so we
should probably have the default entity name changed to be related to
disk's serial number, which will not change.