### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           python-version: "3.8"
       - run: python3 -m pip install -r requirements-dev.txt
-      - run: pytest --cov=custom_components
+      - run: python3 -m pytest --cov=custom_components

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,14 @@ jobs:
   pytest:
     runs-on: "ubuntu-latest"
     name: Run tests
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
       - run: python3 -m pip install -r requirements-dev.txt
       - run: python3 -m pytest --cov=custom_components

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: "ubuntu-latest"
+    name: Run tests
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v1"
+        with:
+          python-version: "3.8"
+      - run: python3 -m pip install -r requirements-dev.txt
+      - run: pytest --cov=custom_components

--- a/README.md
+++ b/README.md
@@ -37,4 +37,7 @@ pip install -r requirements-dev.txt
 
 # One-Time Install of Commit Hooks
 pre-commit install
+
+# Run tests
+python -m pytest tests
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ black==20.8b1
 isort==5.6.4
 pre-commit==2.9.3
 aiotruenas-client===0.4.0
-pytest-homeassistant-custom-component
+pytest-homeassistant-custom-component==0.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black==20.8b1
 isort==5.6.4
 pre-commit==2.9.3
+aiotruenas-client===0.4.0
 pytest-homeassistant-custom-component

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==20.8b1
 isort==5.6.4
 pre-commit==2.9.3
+pytest-homeassistant-custom-component

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,96 @@
+"""Test the TrueNAS config flow."""
+from unittest.mock import patch
+
+from custom_components.truenas.config_flow import CannotConnect, InvalidAuth
+from custom_components.truenas.const import DOMAIN
+from homeassistant import config_entries, setup
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "custom_components.truenas.config_flow.Machine.create",
+    ) as mock_machine, patch(
+        "custom_components.truenas.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "custom_components.truenas.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+
+        mock_machine.return_value.get_system_info.return_value = {
+            "hostname": "somehostname"
+        }
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "somehostname"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "username": "test-username",
+        "password": "test-password",
+        "name": "TrueNAS",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "custom_components.truenas.config_flow.Machine.create",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "custom_components.truenas.config_flow.Machine.create",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "username": "test-username",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from custom_components.truenas.config_flow import CannotConnect, InvalidAuth
 from custom_components.truenas.const import DOMAIN
 from homeassistant import config_entries, setup
+from websockets.exceptions import InvalidURI, SecurityError
 
 
 async def test_form(hass):
@@ -58,7 +59,7 @@ async def test_form_invalid_auth(hass):
 
     with patch(
         "custom_components.truenas.config_flow.Machine.create",
-        side_effect=InvalidAuth,
+        side_effect=SecurityError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -81,7 +82,7 @@ async def test_form_cannot_connect(hass):
 
     with patch(
         "custom_components.truenas.config_flow.Machine.create",
-        side_effect=CannotConnect,
+        side_effect=InvalidURI("invalid_uri"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
This PR adds tests for config flow.  Fixes #8 


Some notes:

* The aiotruenas-client library requirement now has to be included in `requirements-dev.txt` so that it brings it in for testing.  Bumps to this version now has to occur in two places.

* In going to pin `pytest-homeassistant-custom-component` to version 0.1.0, which brings stability to your testing, or you can let it float which will alert you more quickly to changes in the upstream homeassistant testing library, but at the expense of more breakages in testing.  There are pros and cons to both approaches.
