### PR TITLE
Use the proper close method when unloading

### DIFF
--- a/custom_components/truenas/__init__.py
+++ b/custom_components/truenas/__init__.py
@@ -110,7 +110,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
     if unload_ok:
-        await hass.data[DOMAIN]["machine"]._client.close()
+        await hass.data[DOMAIN][entry.entry_id]["machine"].close()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok


### PR DESCRIPTION
`CachingMachine` has a `close` method that we should be using when
unloading this custom integration and no longer need our connection to
the remote machine.

Fixes #11