### PR TITLE
Add api key auth

### DIFF
--- a/custom_components/truenas/__init__.py
+++ b/custom_components/truenas/__init__.py
@@ -131,8 +131,12 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
     if config_entry.version == 1:
         # Version 1 only accepted username and password auth
-        config_entry.data[CONF_AUTH_MODE] = CONF_AUTH_PASSWORD
-        config_entry.data[CONF_API_KEY] = None
+        data = {**config_entry.data}
+
+        data[CONF_AUTH_MODE] = CONF_AUTH_PASSWORD
+        data[CONF_API_KEY] = None
+
+        config_entry.data = data
 
         config_entry.version = 2
 

--- a/custom_components/truenas/const.py
+++ b/custom_components/truenas/const.py
@@ -4,6 +4,10 @@ from homeassistant.helpers import config_validation as cv
 
 DOMAIN = "truenas"
 
+CONF_AUTH_MODE = "auth_mode"
+CONF_AUTH_PASSWORD = "Username + Password"
+CONF_AUTH_API_KEY = "API Key"
+
 DEFAULT_SCAN_INTERVAL_SECONDS = 30
 
 SERVICE_VM_START = "vm_start"

--- a/custom_components/truenas/strings.json
+++ b/custom_components/truenas/strings.json
@@ -3,13 +3,28 @@
   "config": {
     "step": {
       "user": {
-        "data": {
-          "host": "Server Hostname or IP Address",
-          "name": "Name of the Entity",
-          "username": "Username",
-          "password": "Password"
-        }
-      }
+          "data": {
+	      "host": "Server Hostname or IP Address",
+	      "name": "Name of the Entity",
+	      "auth_mode": "Authorization method"
+	},
+	  "title": "Configuration for TrueNAS",
+	  "description": "API key authorization is preferred for TrueNAS 12.0+"
+      },
+	"auth_password": {
+	    "data": {
+		"username": "Username",
+		"password": "Password"
+            },
+	    "title": "Username and Password details for TrueNAS"
+	},
+	"auth_api_key": {
+	    "data": {
+		"api_key": "API Key"
+            },
+	    "title": "Username and Password details for TrueNAS"
+	}
+
     },
     "error": {
       "cannot_connect": "Cannot Connect",

--- a/custom_components/truenas/translations/en.json
+++ b/custom_components/truenas/translations/en.json
@@ -1,23 +1,38 @@
 {
+  "title": "TrueNAS",
   "config": {
-    "abort": {
-      "already_configured": "Already Configured"
+    "step": {
+      "user": {
+          "data": {
+	      "host": "Server Hostname or IP Address",
+	      "name": "Name of the Entity",
+	      "auth_mode": "Authorization method"
+	},
+	  "title": "Configuration for TrueNAS",
+	  "description": "API key authorization is preferred for TrueNAS 12.0+"
+      },
+	"auth_password": {
+	    "data": {
+		"username": "Username",
+		"password": "Password"
+            },
+	    "title": "Username and Password details for TrueNAS"
+	},
+	"auth_api_key": {
+	    "data": {
+		"api_key": "API Key"
+            },
+	    "title": "Username and Password details for TrueNAS"
+	}
+
     },
     "error": {
       "cannot_connect": "Cannot Connect",
       "invalid_auth": "Invalid Auth",
       "unknown": "Unknown Error"
     },
-    "step": {
-      "user": {
-        "data": {
-          "host": "Server Hostname or IP Address",
-          "name": "Name of the Entity",
-          "username": "Username",
-          "password": "Password"
-        }
-      }
+    "abort": {
+      "already_configured": "Already Configured"
     }
-  },
-  "title": "TrueNAS"
+  }
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,8 +7,8 @@ from homeassistant import config_entries, setup
 from websockets.exceptions import InvalidURI, SecurityError
 
 
-async def test_form(hass):
-    """Test we get the form."""
+async def test_form_password(hass):
+    """Test we get the forms using password auth."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -33,20 +33,93 @@ async def test_form(hass):
             result["flow_id"],
             {
                 "host": "1.1.1.1",
+                "name": "TrueNAS",
+                "auth_mode": "Username + Password",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result2["type"] == "form"
+        assert result2["step_id"] == "auth_password"
+
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
                 "username": "test-username",
                 "password": "test-password",
             },
         )
         await hass.async_block_till_done()
 
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == "somehostname"
-    assert result2["data"] == {
-        "host": "1.1.1.1",
-        "username": "test-username",
-        "password": "test-password",
-        "name": "TrueNAS",
-    }
+        assert result3["type"] == "create_entry"
+        assert result3["title"] == "somehostname"
+
+        assert result3["data"] == {
+            "host": "1.1.1.1",
+            "username": "test-username",
+            "password": "test-password",
+            "name": "TrueNAS",
+            "auth_mode": "Username + Password",
+            "api_key": None,
+        }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_api_key(hass):
+    """Test we get the forms using api key auth."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "custom_components.truenas.config_flow.Machine.create",
+    ) as mock_machine, patch(
+        "custom_components.truenas.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "custom_components.truenas.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+
+        mock_machine.return_value.get_system_info.return_value = {
+            "hostname": "somehostname"
+        }
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "name": "TrueNAS",
+                "auth_mode": "API Key",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result2["type"] == "form"
+        assert result2["step_id"] == "auth_api_key"
+
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                "api_key": "someapikey",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result3["type"] == "create_entry"
+        assert result3["title"] == "somehostname"
+
+        assert result3["data"] == {
+            "host": "1.1.1.1",
+            "username": None,
+            "password": None,
+            "name": "TrueNAS",
+            "auth_mode": "API Key",
+            "api_key": "someapikey",
+        }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -65,13 +138,20 @@ async def test_form_invalid_auth(hass):
             result["flow_id"],
             {
                 "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+                "name": "TrueNAS",
+                "auth_mode": "API Key",
             },
         )
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                "api_key": "someapikey",
+            },
+        )
+        await hass.async_block_till_done()
 
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "invalid_auth"}
+    assert result3["type"] == "form"
+    assert result3["errors"] == {"base": "invalid_auth"}
 
 
 async def test_form_cannot_connect(hass):
@@ -88,10 +168,17 @@ async def test_form_cannot_connect(hass):
             result["flow_id"],
             {
                 "host": "1.1.1.1",
-                "username": "test-username",
-                "password": "test-password",
+                "name": "TrueNAS",
+                "auth_mode": "API Key",
             },
         )
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                "api_key": "someapikey",
+            },
+        )
+        await hass.async_block_till_done()
 
-    assert result2["type"] == "form"
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result3["type"] == "form"
+    assert result3["errors"] == {"base": "cannot_connect"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,41 @@
+"""Tests for init module."""
+
+from custom_components import truenas
+from custom_components.truenas.const import CONF_AUTH_MODE, CONF_AUTH_PASSWORD, DOMAIN
+from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL, SOURCE_USER
+from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+async def test_config_flow_entry_migrate(hass):
+    """Test that config flow entry is migrated correctly."""
+    # Start with the config entry at Version 1.
+    old_config_data = {
+        CONF_NAME: "TrueNAS",
+        CONF_USERNAME: "someusername",
+        CONF_PASSWORD: "somepassword",
+    }
+    expected_new_config_data = {
+        CONF_NAME: "TrueNAS",
+        CONF_USERNAME: "someusername",
+        CONF_PASSWORD: "somepassword",
+        CONF_AUTH_MODE: CONF_AUTH_PASSWORD,
+        CONF_API_KEY: None,
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=old_config_data,
+        title="somehostname",
+        version=1,
+        source=SOURCE_USER,
+        connection_class=CONN_CLASS_CLOUD_POLL,
+    )
+
+    entry.add_to_hass(hass)
+    await truenas.async_migrate_entry(hass, entry)
+    await hass.async_block_till_done()
+
+    # Test that config entry is at the current version with new data
+    assert entry.version == 2
+    assert entry.data == expected_new_config_data


### PR DESCRIPTION
This PR adds api key authentication including config flow.  Since the config flow now creates entries with different data, a new version is created and old entries are migrated.

Currently `auth_mode` is included in the config entry since it makes the `config_flow` portion more readable IMO, i.e. we can just use dict.update in the second form rather than pulling out individual items.  It is currently unused other than in config flow.  This is really marginal, so I'm fine taking it out.

I tested the api authorization on a test ha server on my TrueNAS server, but I did not test the migration on a live server.

Fixes #4 