### PR TITLE
Ensure the version of aiotruenas-client is synced

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==20.8b1
 isort==5.6.4
 pre-commit==2.9.3
-aiotruenas-client===0.4.0
+aiotruenas-client==0.4.0
 pytest-homeassistant-custom-component==0.1.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,52 @@
+import json
+import os
+import unittest
+from typing import List, Tuple
+
+import pkg_resources
+
+CLIENT_LIBRARY = "aiotruenas-client"
+MANIFEST_FILE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "..",
+    "custom_components",
+    "truenas",
+    "manifest.json",
+)
+REQUIREMENTS_DEV_FILE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "..", "requirements-dev.txt"
+)
+
+
+class TestRequirements(unittest.TestCase):
+    def test_aiotruenas_client_synced(self) -> None:
+        manifest_version = [
+            r[1] for r in self._get_manifest_data() if r[0] == CLIENT_LIBRARY
+        ]
+        requirements_dev_version = [
+            r[1] for r in self._get_requirements_dev_data() if r[0] == CLIENT_LIBRARY
+        ]
+        self.assertEqual(
+            manifest_version,
+            requirements_dev_version,
+            f"The version of {CLIENT_LIBRARY} must match in `manifest.json` and `requirements-dev.txt`",
+        )
+
+    def _get_manifest_data(self) -> List[Tuple[str, List[Tuple[str, str]]]]:
+        with open(MANIFEST_FILE, "r") as manifest:
+            requirements = json.load(manifest)["requirements"]
+            return [
+                (req.key, req.specs)
+                for req in pkg_resources.parse_requirements(requirements)
+            ]
+
+    def _get_requirements_dev_data(self) -> List[Tuple[str, List[Tuple[str, str]]]]:
+        with open(REQUIREMENTS_DEV_FILE, "r") as requirements:
+            return [
+                (req.key, req.specs)
+                for req in pkg_resources.parse_requirements(requirements)
+            ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This ensures that `manifest.json`, which Home Assistant uses to fetch
packages from, and `requirements-dev.txt`, which our testing library
uses to fetch packages from, have the same version of
`aiotruenas-client`.

Fixes #13