### PR TITLE
Fix error upon setup that would fail to setup entities until restart

### DIFF
--- a/custom_components/truenas/config_flow.py
+++ b/custom_components/truenas/config_flow.py
@@ -63,6 +63,7 @@ async def validate_input(hass: core.HomeAssistant, data: Dict[str, Any]) -> Dict
         raise CannotConnect from exc
 
     info = await machine.get_system_info()
+    await machine.close()
     return {
         "hostname": info["hostname"],
     }

--- a/custom_components/truenas/config_flow.py
+++ b/custom_components/truenas/config_flow.py
@@ -45,7 +45,7 @@ DATA_SCHEMA_API_KEY = vol.Schema(
 )
 
 
-async def validate_input(hass: core.HomeAssistant, data) -> Dict:
+async def validate_input(hass: core.HomeAssistant, data: Dict[str, Any]) -> Dict:
     """Validate the user input allows us to connect.
 
     Data has the keys from DATA_SCHEMA with values provided by the user.


### PR DESCRIPTION
We need to close the connection in `validate_input` otherwise we get an exception and the user has to restart Home Assistant in order to proceed.