### PR TITLE
Update python support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version:
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version:
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
Home Assistant doesn't work with 3.8 anymore, and they now support 3.10.