### PR TITLE
Omit "title" in translations, as well as "TrueNAS"

### DIFF
--- a/custom_components/truenas/strings.json
+++ b/custom_components/truenas/strings.json
@@ -1,30 +1,28 @@
 {
-  "title": "TrueNAS",
   "config": {
     "step": {
       "user": {
-          "data": {
-	      "host": "Server Hostname or IP Address",
-	      "name": "Name of the Entity",
-	      "auth_mode": "Authorization method"
-	},
-	  "title": "Configuration for TrueNAS",
-	  "description": "API key authorization is preferred for TrueNAS 12.0+"
+        "data": {
+          "host": "Server Hostname or IP Address",
+          "name": "Name of the Entity",
+          "auth_mode": "Authorization method"
+        },
+        "title": "Connection Configuration",
+        "description": "API key authorization is preferred, but you can configure with a username and password too."
       },
-	"auth_password": {
-	    "data": {
-		"username": "Username",
-		"password": "Password"
-            },
-	    "title": "Username and Password details for TrueNAS"
-	},
-	"auth_api_key": {
-	    "data": {
-		"api_key": "API Key"
-            },
-	    "title": "Username and Password details for TrueNAS"
-	}
-
+      "auth_password": {
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "title": "Username and Password Configuration"
+      },
+      "auth_api_key": {
+        "data": {
+          "api_key": "API Key"
+        },
+        "title": "API Configuration"
+      }
     },
     "error": {
       "cannot_connect": "Cannot Connect",

--- a/custom_components/truenas/translations/en.json
+++ b/custom_components/truenas/translations/en.json
@@ -1,30 +1,28 @@
 {
-  "title": "TrueNAS",
   "config": {
     "step": {
       "user": {
-          "data": {
-	      "host": "Server Hostname or IP Address",
-	      "name": "Name of the Entity",
-	      "auth_mode": "Authorization method"
-	},
-	  "title": "Configuration for TrueNAS",
-	  "description": "API key authorization is preferred for TrueNAS 12.0+"
+        "data": {
+          "host": "Server Hostname or IP Address",
+          "name": "Name of the Entity",
+          "auth_mode": "Authorization method"
+        },
+        "title": "Connection Configuration",
+        "description": "API key authorization is preferred, but you can configure with a username and password too."
       },
-	"auth_password": {
-	    "data": {
-		"username": "Username",
-		"password": "Password"
-            },
-	    "title": "Username and Password details for TrueNAS"
-	},
-	"auth_api_key": {
-	    "data": {
-		"api_key": "API Key"
-            },
-	    "title": "Username and Password details for TrueNAS"
-	}
-
+      "auth_password": {
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "title": "Username and Password Configuration"
+      },
+      "auth_api_key": {
+        "data": {
+          "api_key": "API Key"
+        },
+        "title": "API Configuration"
+      }
     },
     "error": {
       "cannot_connect": "Cannot Connect",


### PR DESCRIPTION
Per the [documentation](https://developers.home-assistant.io/docs/internationalization/core?_highlight=brand#title), it will fallback to the integration name, and should not be set if it is a brand name.  Additionally, we should remove "TrueNAS" from all titles.